### PR TITLE
ci(actions): 更新工作流动作版本

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Resolve pull request
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pulls = context.payload.workflow_run.pull_requests || [];
@@ -54,7 +54,7 @@ jobs:
 
       - name: Check changed files
         if: steps.pr.outputs.eligible == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pull_number = Number('${{ steps.pr.outputs.number }}');

--- a/.github/workflows/dependency-patch-release.yml
+++ b/.github/workflows/dependency-patch-release.yml
@@ -43,18 +43,18 @@ jobs:
           fi
 
       - name: Checkout package
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.checkout-ref.outputs.ref }}
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
 

--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,7 +31,7 @@ jobs:
           fi
 
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.input.outputs.tag_name }}
           fetch-depth: 0
@@ -87,12 +87,12 @@ jobs:
       - validate-release
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate-release.outputs.tag_name }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -103,7 +103,7 @@ jobs:
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dists
           path: dist/
@@ -121,7 +121,7 @@ jobs:
       url: https://pypi.org/project/league-tools/${{ needs.validate-release.outputs.version }}/
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-dists
           path: dist/


### PR DESCRIPTION
## Why
- GitHub Actions 已提示 Node.js 20 action 即将淘汰，需要迁移到支持 Node.js 24 的新版 action。

## What
- 更新 workflow 中的 checkout、setup-python、artifact、github-script 和 setup-uv action 版本。
- 保留 PyPI 发布 action 的 release/v1 推荐通道。

## Test
- workflow YAML 解析通过。
- 旧 action 引用扫描无结果。
- uv run pytest -q tests/test_dependency_release_scripts.py 通过。
- uv lock --check 通过。
- uv run pytest -q 通过。
- uv build 通过。
- git diff --check 通过。