### PR TITLE
ci(deps): 收紧依赖自动合并策略

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,20 +10,26 @@ updates:
       time: "10:00"
       timezone: "Asia/Shanghai"
     open-pull-requests-limit: 5
+    groups:
+      runtime-dependencies:
+        patterns:
+          - "xxhash"
+          - "loguru"
+          - "zstd"
+          - "lxml"
+          - "quick-xmltodict"
+          - "urllib3"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        patterns:
+          - "psutil"
+          - "pytest"
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
-      include: "scope"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: "package"
-    schedule:
-      interval: "weekly"
-      day: "wednesday"
-      time: "10:20"
-      timezone: "Asia/Shanghai"
-    open-pull-requests-limit: 3
-    commit-message:
-      prefix: "chore"
       include: "scope"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -38,21 +38,44 @@ jobs:
             });
 
             const title = data.title || '';
+            const titleLower = title.toLowerCase();
+            const headRef = data.head.ref || '';
+            const labels = (data.labels || []).map((label) => label.name || '');
+            const uvUpdate = headRef.startsWith('dependabot/uv/') || labels.includes('python:uv');
+            const runtimeGroupUpdate =
+              headRef.includes('/runtime-dependencies') ||
+              titleLower.includes('runtime-dependencies');
+            const devUpdate =
+              titleLower.includes('(deps-dev)') ||
+              headRef.includes('/development-dependencies') ||
+              headRef.includes('/dev-dependencies') ||
+              titleLower.includes('development-dependencies') ||
+              titleLower.includes('dev-dependencies');
             const versionMatch = title.match(/\bfrom\s+v?(\d+)(?:\.\d+)*\s+to\s+v?(\d+)(?:\.\d+)*/i);
-            const majorUpdate = !versionMatch || versionMatch[1] !== versionMatch[2];
+            const majorUpdate = runtimeGroupUpdate
+              ? false
+              : !versionMatch || versionMatch[1] !== versionMatch[2];
             const eligible =
               data.user?.login === 'dependabot[bot]' &&
+              uvUpdate &&
+              runtimeGroupUpdate &&
               data.base.ref === 'package' &&
-              data.head.ref.startsWith('dependabot/') &&
+              headRef.startsWith('dependabot/') &&
               data.mergeable_state !== 'dirty' &&
+              !devUpdate &&
               !majorUpdate;
 
             core.info(`title=${title}`);
+            core.info(`head_ref=${headRef}`);
+            core.info(`uv_update=${uvUpdate}`);
+            core.info(`runtime_group_update=${runtimeGroupUpdate}`);
+            core.info(`dev_update=${devUpdate}`);
             core.info(`major_update=${majorUpdate}`);
             core.setOutput('eligible', eligible ? 'true' : 'false');
             core.setOutput('number', String(data.number));
 
       - name: Check changed files
+        id: files
         if: steps.pr.outputs.eligible == 'true'
         uses: actions/github-script@v9
         with:
@@ -65,33 +88,26 @@ jobs:
               per_page: 100,
             });
 
-            const allowed = new Set([
-              'pyproject.toml',
-              'uv.lock',
-              '.github/dependabot.yml',
-            ]);
-            const allowedWorkflow = /^\.github\/workflows\/[^/]+\.ya?ml$/;
+            const changed = files.map((file) => file.filename);
+            const allowed = new Set(['pyproject.toml', 'uv.lock']);
             const unexpected = files
               .map((file) => file.filename)
-              .filter((name) => !allowed.has(name) && !allowedWorkflow.test(name));
+              .filter((name) => !allowed.has(name));
 
             if (unexpected.length > 0) {
               core.setFailed(`Unexpected files in Dependabot PR: ${unexpected.join(', ')}`);
             }
+            if (!changed.includes('pyproject.toml')) {
+              core.info('Dependabot PR does not update pyproject.toml; leaving it open.');
+            }
+            core.setOutput(
+              'has_pyproject',
+              changed.includes('pyproject.toml') ? 'true' : 'false'
+            );
 
       - name: Merge pull request
-        if: steps.pr.outputs.eligible == 'true'
+        if: steps.pr.outputs.eligible == 'true' && steps.files.outputs.has_pyproject == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: gh pr merge "$PR_NUMBER" --squash --delete-branch --repo "${{ github.repository }}"
-
-      - name: Dispatch dependency release check
-        if: steps.pr.outputs.eligible == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh workflow run dependency-patch-release.yml \
-            --repo "${{ github.repository }}" \
-            --ref package \
-            -f dry_run=false

--- a/tests/test_dependency_release_scripts.py
+++ b/tests/test_dependency_release_scripts.py
@@ -18,6 +18,27 @@ def _load_script(name: str) -> ModuleType:
     return module
 
 
+def test_dependency_automation_config_groups_runtime_and_blocks_dev_updates() -> None:
+    dependabot = (ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8")
+    automerge = (ROOT / ".github" / "workflows" / "dependabot-automerge.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'package-ecosystem: "github-actions"' not in dependabot
+    assert "runtime-dependencies:" in dependabot
+    for name in ["xxhash", "loguru", "zstd", "lxml", "quick-xmltodict", "urllib3"]:
+        assert f'- "{name}"' in dependabot
+    assert "development-dependencies:" in dependabot
+    for name in ["psutil", "pytest"]:
+        assert f'- "{name}"' in dependabot
+
+    assert "runtimeGroupUpdate" in automerge
+    assert "runtimeGroupUpdate &&" in automerge
+    assert "devUpdate" in automerge
+    assert "has_pyproject" in automerge
+    assert "dependency-patch-release.yml" not in automerge
+
+
 def test_sync_runtime_dependency_bounds_only_updates_project_dependencies(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Why
- 避免同一轮 runtime 依赖更新拆成多个 PR 后连续触发多个 patch release。
- 开发依赖只作为 PR 提醒，不自动合入 package。

## What
- 将 uv runtime 直接依赖配置为 runtime-dependencies 分组。
- 移除 github-actions Dependabot 配置。
- 自动合并仅接受 runtime-dependencies 分组 PR，并移除重复 dispatch 发版工作流。
- 增加配置回归测试。

## Test
- uv run pytest -q：36 passed
- uv run --with ruff ruff check tests\\test_dependency_release_scripts.py .github\\scripts：通过
- uv run --with ruff ruff format --check tests\\test_dependency_release_scripts.py .github\\scripts：通过
- .github/**/*.yml PyYAML 解析：通过
- actionlint .github\\workflows\\*.yml：通过
- git diff --check：通过

## Notes
- 全仓库 ruff check/format 仍有既有 src/scripts/tests 问题，未纳入本次修复。